### PR TITLE
Small oversight on the reverse bilinear transform when no lowcut filter is applied

### DIFF
--- a/python/fdtd/process_outputs.py
+++ b/python/fdtd/process_outputs.py
@@ -120,7 +120,7 @@ class ProcessOutputs:
             r_out_f = sosfilt(sos,r_out)
         elif apply_int: #shouldn't really use this without lowcut, but here in case
             b = Ts/2*npa([1,1])
-            a = npa([1,1])
+            a = npa([1, -1])
             r_out_f = lfilter(b,a,r_out)
             self.print('applying integrator')
         else:


### PR DESCRIPTION
Since applying this bilinear transform before

```        
b = 2 / Ts * npa([1.0, -1.0])  # don't need Ts scaling but simpler to keep for receiver post-processing
a = npa([1.0, 1.0])
```

The correct reverse operation should be : 
```
b = Ts / 2 * npa([1, 1])
a = npa([1, -1])
```

Btw, I didn't get why the bilinear transform helps with single precision operation. Is there a signal processing reason behind this method ? 

Thanks for all of your work !
